### PR TITLE
Additional task to run at set interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ every login and wrote a new script that makes use of that.
 _Note: If you had v1 of the script installed, it is automatically uninstalled if
 you install v2._
 
+## New in v2.5
+
+The affinity will now be set periodically in addition to only on login. For more
+information, see
+[#11](https://github.com/Gobidev/voicemeeter-auto-affinity/pull/11).
+
 ## How to Install
 
 To install the script, download the `install.bat` file from the
@@ -26,11 +32,12 @@ and run it. That's it!
 
 ## How to Uninstall
 
-If you no longer want the audiodg affinity to be set at login, run the following
-command from an administrator command prompt:
+To remove the Task Scheduler tasks, run the following commands from an
+administrator command prompt:
 
 ```bat
 schtasks /delete /f /tn audiodg-affinity
+schtasks /delete /f /tn audiodg-affinity-recurring
 ```
 
 ## The Problem

--- a/install.bat
+++ b/install.bat
@@ -64,6 +64,9 @@ del set-audiodg-affinity.bat 2>NUL
 :: add task scheduler job
 schtasks /create /sc ONLOGON /tn audiodg-affinity /delay 0000:20 /tr "wscript \"%UserProfile%\set-audiodg-affinity.vbs\"" /rl HIGHEST
 
+:: Creating scheduled task so it is more persistently applying changes as the process is controlled by the Windows Audio service and will stop and restart process as needed
+schtasks /create /sc MINUTE /tn audiodg-affinity-recurring /mo 5 /tr "wscript \"%UserProfile%\set-audiodg-affinity.vbs\"" /rl HIGHEST
+
 :: run vbs script once to set the affinity for current session
 wscript "%UserProfile%\set-audiodg-affinity.vbs"
 


### PR DESCRIPTION
Problem:
Due to the nature of the audiodg being a process that is controlled by Windows Audio service. It is at mercy to it and as such the process can and will be stopped and restarted by this service. When this occurs the affinity and priority are lost upon the restart of this process.

Solution:
An additional scheduled task that will ensure that if the process was restarted it will have the affinity and priority changes set back to what we want (in our case core 0 and high priority). I have been using this fix on top of your solution for the past two weeks with no problems. 